### PR TITLE
fix(warnings): Wconversion with gfortran-13.2 compilation

### DIFF
--- a/src/rngff/linear_congruential_m.f90
+++ b/src/rngff/linear_congruential_m.f90
@@ -50,7 +50,7 @@ contains
         call self%next(tmp)
         negative = tmp >= 0.5 ! Use the "first bit" of tmp as a sign
         tmp = 2*tmp - merge(1, 0, negative) ! Drop the "first bit" of tmp
-        harvest = tmp * huge(harvest) * merge(-1, 1, negative)
+        harvest = int(tmp * huge(harvest) * merge(-1, 1, negative), kind=int32)
     end subroutine
 
     elemental subroutine next_int64(self, harvest)
@@ -63,7 +63,7 @@ contains
         call self%next(tmp)
         negative = tmp >= 0.5 ! Use the "first bit" of tmp as a sign
         tmp = 2*tmp - merge(1, 0, negative) ! Drop the "first bit" of tmp
-        harvest = tmp * huge(harvest) * merge(-1, 1, negative)
+        harvest = int(tmp * real(huge(harvest), kind=real64) * merge(-1, 1, negative), kind=int64)
     end subroutine
 
     elemental subroutine next_real32(self, harvest)
@@ -84,7 +84,7 @@ contains
 
         z = self%seeds_(1) - self%seeds_(2)
         if (z<1) z = z + m(1) - 1
-        harvest = z * over_m1
+        harvest = real(z * over_m1, kind=real32)
         if (harvest >= 1) harvest = 0
     end subroutine
 

--- a/test/sanity_checks_m.f90
+++ b/test/sanity_checks_m.f90
@@ -265,7 +265,7 @@ contains
         samples_in_bin = 0
         bin_width = (real(huge(samples)) / num_bins) * 2
         do i = 1, size(samples)
-            bin = floor(samples(i)/bin_width + huge(samples)/bin_width) + 1
+            bin = floor(samples(i)/bin_width + real(huge(samples), kind=real32)/bin_width) + 1
             samples_in_bin(bin) = samples_in_bin(bin) + 1
         end do
         distribution = real(samples_in_bin, kind(distribution)) / size(samples)
@@ -283,7 +283,7 @@ contains
         samples_in_bin = 0
         bin_width = (real(huge(samples)) / num_bins) * 2
         do i = 1, size(samples)
-            bin = floor(samples(i)/bin_width + huge(samples)/bin_width) + 1
+            bin = floor(real(samples(i), kind=real32)/bin_width + real(huge(samples), kind=real32)/bin_width) + 1
             samples_in_bin(bin) = samples_in_bin(bin) + 1
         end do
         distribution = real(samples_in_bin, kind(distribution)) / size(samples)


### PR DESCRIPTION
These changes explicitly perform the conversions that were implicitly performed by the compiler (and which produced a warning).

These changes remove all warnings in `rngff` when running `fpm test` using the `gfortran-13.2`  compiler on `ubuntu-22.04`

Unit tests pass, and running the entire `FAVPRO` test suite with these changes does not result in any changes to the outputs (not even epsilons).

If these change are merged, could you also create a new release for `rngff`?